### PR TITLE
Add Smartsupp chat loader script to filter list

### DIFF
--- a/filterlist.txt
+++ b/filterlist.txt
@@ -35,6 +35,7 @@
 ||leadconnect.ipmaxi.se/*
 ||static.small.chat/messenger.js
 ||smartsupp-widget-161959.c.cdn77.org/build/smartchat-2.3.20.min.js
+||www.smartsuppchat.com/loader.js?
 ||plugins.help.com/*
 ||js.gs-chat.com/*"
 ||widget.customerly.io/*


### PR DESCRIPTION
Appartently Smartsupp is using this URL to load the resources from their chat widget. I just tested the new filter on this page: `https://cr.epaenlinea.com/epa-ambientes/un-cuarto-de-estudio-bien-equipado.html` and the new filter worked correctly.